### PR TITLE
Add Ephemeral Quick Assist and Conversation Clearing Functionality

### DIFF
--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -1,3 +1,5 @@
+## Post Commit Logic Flow
+
 ```mermaid
 graph TD
     A[Git Commit] --> B[Post-Commit Hook]
@@ -12,3 +14,27 @@ graph TD
     H --> J[Save Logs]
     I --> J
 ``` 
+
+
+## Conversational Flow
+```mermaid
+sequenceDiagram
+    participant D as Developer
+    participant E as Extension
+    participant S as Server
+    participant L as LLM
+
+    D->>E: Commits code
+    E->>S: Start PR conversation
+    S->>L: Initial prompt with full diff
+    L->>S: Initial draft PR
+    S->>E: Return draft + conversation ID
+    E->>D: Show draft PR
+
+    D->>E: Request clarification
+    E->>S: Continue conversation (ID + question)
+    S->>L: Contextual prompt
+    L->>S: Clarification response
+    S->>E: Return response
+    E->>D: Show clarification
+```

--- a/internal/llm/conversation_manager.go
+++ b/internal/llm/conversation_manager.go
@@ -1,0 +1,136 @@
+// internal/llm/conversation_manager.go
+
+package llm
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConversationManager handles stateful conversations with context management
+type ConversationManager struct {
+	conversations map[string]*Conversation
+	mutex         sync.RWMutex
+}
+
+// Conversation represents a single developer's conversation thread
+type Conversation struct {
+	ID             string
+	Ephemeral      bool
+	InitialDiff    string
+	Messages       []Message
+	LastActivity   time.Time
+	DiffTruncation bool
+}
+
+// NewConversationManager creates a new conversation manager
+func NewConversationManager() *ConversationManager {
+	return &ConversationManager{
+		conversations: make(map[string]*Conversation),
+	}
+}
+
+// StartConversation initializes a new conversation
+func (cm *ConversationManager) StartConversation(id, initialDiff string, ephemeral bool) *Conversation {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	conv := &Conversation{
+		ID:           id,
+		Ephemeral:    ephemeral,
+		InitialDiff:  initialDiff,
+		Messages:     make([]Message, 0),
+		LastActivity: time.Now(),
+	}
+
+	cm.conversations[id] = conv
+	return conv
+}
+
+// GetConversation retrieves an existing conversation
+func (cm *ConversationManager) GetConversation(id string) (*Conversation, bool) {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+
+	conv, exists := cm.conversations[id]
+	return conv, exists
+}
+
+// RemoveConversation removes a conversation from memory (useful for ephemeral clearing)
+func (cm *ConversationManager) RemoveConversation(id string) {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+	delete(cm.conversations, id)
+}
+
+// Cleanup removes stale conversations
+func (cm *ConversationManager) Cleanup(maxAge time.Duration) {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	now := time.Now()
+	for id, conv := range cm.conversations {
+		if now.Sub(conv.LastActivity) > maxAge {
+			delete(cm.conversations, id)
+		}
+	}
+}
+
+// AddMessage adds a new message to the conversation
+func (c *Conversation) AddMessage(role, content string) {
+	c.Messages = append(c.Messages, Message{
+		Role:    role,
+		Content: content,
+	})
+	c.LastActivity = time.Now()
+}
+
+// BuildContext constructs the conversation context with proper diff management
+func (c *Conversation) BuildContext() []Message {
+	context := make([]Message, 0, len(c.Messages)+2)
+
+	// If this is ephemeral and no initial diff is relevant, you could skip
+	// or heavily simplify. But for demonstration, we apply the same logic.
+	// Add system message
+	context = append(context, Message{
+		Role:    "system",
+		Content: "You are a helpful assistant for creating and refining pull requests.",
+	})
+
+	// Add initial diff if within first two turns or not truncated
+	if c.InitialDiff != "" {
+		if len(c.Messages) < 4 || !c.DiffTruncation {
+			context = append(context, Message{
+				Role:    "user",
+				Content: fmt.Sprintf("Initial code changes:\n%s", c.InitialDiff),
+			})
+		} else {
+			// Add truncated diff after two turns
+			context = append(context, Message{
+				Role:    "user",
+				Content: fmt.Sprintf("Initial code changes (truncated):\n%s", truncateDiff(c.InitialDiff)),
+			})
+			c.DiffTruncation = true
+		}
+	}
+
+	// Add conversation messages
+	context = append(context, c.Messages...)
+	return context
+}
+
+// truncateDiff reduces the size of large diffs while preserving important context
+func truncateDiff(diff string) string {
+	const maxLines = 100
+	lines := strings.Split(diff, "\n")
+	if len(lines) <= maxLines {
+		return diff
+	}
+
+	// Keep first and last 50 lines
+	start := lines[:50]
+	end := lines[len(lines)-50:]
+	return strings.Join(append(start, end...), "\n")
+}

--- a/internal/llm/draft_context.go
+++ b/internal/llm/draft_context.go
@@ -1,3 +1,5 @@
+// internal/llm/draft_context.go
+
 package llm
 
 import (
@@ -10,6 +12,7 @@ import (
 	"github.com/soyuz43/prbuddy-go/internal/utils"
 )
 
+// SaveDraftContext saves conversation messages to disk for a specific branch/commit
 func SaveDraftContext(branchName, commitHash string, context []Message) error {
 	repoPath, err := utils.GetRepoPath()
 	if err != nil {
@@ -37,7 +40,7 @@ func SaveDraftContext(branchName, commitHash string, context []Message) error {
 	return nil
 }
 
-// LoadDraftContext retrieves saved conversation context
+// LoadDraftContext retrieves saved conversation context for a specific branch/commit
 func LoadDraftContext(branchName, commitHash string) ([]Message, error) {
 	repoPath, err := utils.GetRepoPath()
 	if err != nil {


### PR DESCRIPTION
**Draft Pull Request**  
_Add Ephemeral Quick Assist and Conversation Clearing Functionality_

---

### Summary

This PR introduces **ephemeral Quick Assist** sessions for short-lived conversations with the AI assistant and a **clear** endpoint to reset ephemeral context on demand. It also preserves the existing persistent multi-turn PR drafting flow, ensuring all changes align with the new ephemeral vs. persistent usage scenarios.

---

### What Changed?

1. **Ephemeral Quick Assist**  
   - Users can start a Quick Assist session without persisting it to `.git/pr_buddy_db`.  
   - In `QuickAssistHandler`, a user can set `"ephemeral": true` to create or continue a short-lived conversation.

2. **Conversation Clearing**  
   - Added a new route `/extension/quick-assist/clear` that removes an ephemeral conversation from memory entirely.

3. **Fallback vs. Extension**  
   - Logic is in place to let CLI commands output directly to the terminal if no extension is active (outside the scope of these snippet changes, but function calls like `CheckExtensionInstalled()` can be used in your CLI commands).

4. **Context & Diff Management**  
   - For ephemeral Quick Assist, no `initialDiff` is used by default.  
   - Persistent PR draft logic remains the same, with diffs truncated after two full turns.

---

### Implementation Details

Below are **selected code snippets** (≤ 5 lines each) illustrating critical points:

<details>
<summary><strong>1. New Routes for Ephemeral Quick Assist</strong></summary>

```go
// server.go (excerpt)
router.HandleFunc("/extension/quick-assist", QuickAssistHandler)
router.HandleFunc("/extension/quick-assist/clear", QuickAssistClearHandler)
```

```go
// server.go (excerpt)
var req struct {
  ConversationID string `json:"conversationId"`
  Message        string `json:"message"`
  Ephemeral      bool   `json:"ephemeral"`
}
```
</details>

<details>
<summary><strong>2. Ephemeral Parameter in Conversation Creation</strong></summary>

```go
// llm_client.go (excerpt)
conv := conversationManager.StartConversation(
  conversationID,
  "", // no initial diff
  ephemeral,
)
```
</details>

<details>
<summary><strong>3. Clearing an Ephemeral Conversation</strong></summary>

```go
// conversation_manager.go (excerpt)
func (cm *ConversationManager) RemoveConversation(id string) {
  cm.mutex.Lock()
  delete(cm.conversations, id)
  cm.mutex.Unlock()
}
```

```go
// server.go (excerpt)
conversationManager.RemoveConversation(req.ConversationID)
```
</details>

---

### Flow Diagrams

#### 1. Ephemeral Quick Assist Flow

```mermaid
sequenceDiagram
    participant VSCode as VSCode Extension
    participant Server as PRBuddy-Go (server.go)
    participant CM as ConversationManager
    participant LLM as LLM API

    VSCode->>Server: POST /extension/quick-assist { ephemeral=true, message="..." }
    alt New or Missing conversationId
        Server->>CM: StartConversation(id, "", ephemeral=true)
    else Existing conversationId
        Server->>CM: GetConversation(id)
    end
    Server->>CM: AddMessage(user, "...")
    CM->>CM: BuildContext (incl. no initial diff for ephemeral)
    Server->>LLM: Send messages[]
    LLM-->>Server: JSON response
    Server->>CM: AddMessage(assistant, response)
    Server-->>VSCode: {"response": "..."}
```

**Explanation**:  
1. The user or extension sends a message with `"ephemeral": true`.  
2. If no conversation is found, a **new** ephemeral conversation is created.  
3. The conversation manager updates context in memory only.  
4. The server forwards the user’s message to the LLM, receives a response, and sends it back.

---

#### 2. Clearing Ephemeral Conversation

```mermaid
sequenceDiagram
    participant VSCode as VSCode Extension
    participant Server as PRBuddy-Go
    participant CM as ConversationManager

    VSCode->>Server: POST /extension/quick-assist/clear { conversationId="..." }
    Server->>CM: RemoveConversation(id)
    CM->>Server: Acknowledged
    Server-->>VSCode: {"status":"cleared"}
```

**Explanation**:  
When the extension (or user) calls `/quick-assist/clear`, that conversation is entirely removed from in-memory tracking, resetting any ephemeral context.

---

### Testing

- **Ephemeral Quick Assist**  
  1. POST `/extension/quick-assist` with `{"message":"Hi","ephemeral":true}`  
  2. Confirm the server returns a valid AI response.  
  3. Verify no `.git/pr_buddy_db` files are created.

- **Clearing Context**  
  1. Track conversation ID from step above.  
  2. POST `/extension/quick-assist/clear` with `{"conversationId":"ephemeral-..."}`
  3. Attempt to reuse that ID to confirm it’s gone or results in a new ephemeral conversation.

- **Persistent Draft**  
  1. Start a PR draft via `StartPRConversation` or `GenerateDraftPR`.  
  2. Confirm `.git/pr_buddy_db` stores `draft_context.json`.  
  3. Reload with `/extension/drafts/load` to verify persistence.

---

### Closing Notes

- These changes preserve your existing PR drafting workflow, while **adding** ephemeral conversations for quick help.  
- The new `/extension/quick-assist/clear` endpoint complements ephemeral usage by fully resetting context in memory.  
- Future enhancements could integrate environment checks (e.g., `CheckExtensionInstalled()`) to decide between terminal fallback vs. extension-based flows.