### PR TITLE
Add Color Package and Improve Interactive PR Generation

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -7,14 +7,18 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/soyuz43/prbuddy-go/internal/utils"
+	"github.com/soyuz43/prbuddy-go/internal/utils/colorutils"
 	"github.com/spf13/cobra"
 )
 
 // Color definitions
 var (
-	cyan  = color.New(color.FgCyan).SprintFunc()
-	green = color.New(color.FgGreen).SprintFunc()
-	bold  = color.New(color.Bold).SprintFunc()
+	cyan    = colorutils.Cyan
+	green   = colorutils.Green
+	yellow  = colorutils.Yellow
+	red     = colorutils.Red
+	magenta = colorutils.Magenta
+	bold    = colorutils.Bold
 )
 
 // Root command

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -12,11 +12,15 @@ import (
 )
 
 // Color definitions
+
 var (
-	cyan    = colorutils.Cyan
-	green   = colorutils.Green
-	yellow  = colorutils.Yellow
-	red     = colorutils.Red
+	cyan  = colorutils.Cyan
+	green = colorutils.Green
+	//lint:ignore U1000 This variable is intentionally unused.
+	yellow = colorutils.Yellow
+	//lint:ignore U1000 This variable is intentionally unused.
+	red = colorutils.Red
+	//lint:ignore U1000 This variable is intentionally unused.
 	magenta = colorutils.Magenta
 	bold    = colorutils.Bold
 )

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,31 +15,31 @@ var initCmd = &cobra.Command{
 	Short: "Initialize PRBuddy-Go in the current Git repository.",
 	Long:  `Installs a post-commit hook and creates the .git/pr_buddy_db directory.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("[prbuddy-go] Initializing PRBuddy-Go...")
+		fmt.Println("[PRBuddy-Go] Initializing PRBuddy-Go...")
 
 		// 1. Install post-commit hook
 		if err := hooks.InstallPostCommitHook(); err != nil {
-			fmt.Printf("[prbuddy-go] Error installing post-commit hook: %v\n", err)
+			fmt.Printf("[PRBuddy-Go] Error installing post-commit hook: %v\n", err)
 			return
 		}
-		fmt.Println("[prbuddy-go] Post-commit hook installation complete.")
+		fmt.Println("[PRBuddy-Go] Post-commit hook installation complete.")
 
 		// 2. Create pr_buddy_db directory
 		repoPath, err := utils.GetRepoPath()
 		if err != nil {
-			fmt.Printf("[prbuddy-go] Error retrieving repository path: %v\n", err)
+			fmt.Printf("[PRBuddy-Go] Error retrieving repository path: %v\n", err)
 			return
 		}
 
 		prBuddyDBPath := filepath.Join(repoPath, ".git", "pr_buddy_db")
 		err = os.MkdirAll(prBuddyDBPath, 0750)
 		if err != nil {
-			fmt.Printf("[prbuddy-go] Error creating pr_buddy_db directory: %v\n", err)
+			fmt.Printf("[PRBuddy-Go] Error creating pr_buddy_db directory: %v\n", err)
 			return
 		}
 
-		fmt.Printf("[prbuddy-go] Created directory: %s\n", prBuddyDBPath)
-		fmt.Println("[prbuddy-go] Initialization complete.")
+		fmt.Printf("[PRBuddy-Go] Created directory: %s\n", prBuddyDBPath)
+		fmt.Println("[PRBuddy-Go] Initialization complete.")
 	},
 }
 

--- a/cmd/what.go
+++ b/cmd/what.go
@@ -16,16 +16,16 @@ var whatCmd = &cobra.Command{
 	Long: `Analyzes staged, unstaged, and untracked changes in the repository 
 and provides a natural language summary using the LLM.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("[prbuddy-go] Running 'what' command...")
+		fmt.Println("[PRBuddy-Go] Running 'what' command...")
 
 		// Check if there are any commits in the repository
 		commitCount, err := utils.ExecuteGitCommand("rev-list", "--count", "HEAD")
 		if err != nil {
-			fmt.Printf("[prbuddy-go] Error checking commits: %v\n", err)
+			fmt.Printf("[PRBuddy-Go] Error checking commits: %v\n", err)
 			return
 		}
 		if commitCount == "0" {
-			fmt.Println("[prbuddy-go] No commits found in the repository. Please make a commit first.")
+			fmt.Println("[PRBuddy-Go] No commits found in the repository. Please make a commit first.")
 			return
 		}
 
@@ -33,10 +33,10 @@ and provides a natural language summary using the LLM.`,
 		summary, err := llm.GenerateWhatSummary()
 		if err != nil {
 			if err.Error() == "no changes detected since the last commit" {
-				fmt.Println("[prbuddy-go] No changes detected.")
+				fmt.Println("[PRBuddy-Go] No changes detected.")
 				return
 			}
-			fmt.Printf("[prbuddy-go] Error generating summary: %v\n", err)
+			fmt.Printf("[PRBuddy-Go] Error generating summary: %v\n", err)
 			return
 		}
 

--- a/internal/hooks/install_hook.go
+++ b/internal/hooks/install_hook.go
@@ -20,7 +20,7 @@ func InstallPostCommitHook() error {
 	postCommitPath := filepath.Join(hooksDir, "post-commit")
 
 	hookContent := `#!/bin/bash
-echo "[prbuddy-go] Detected commit. Running post-commit hook..."
+echo "[PRBuddy-Go] Detected commit. Running post-commit hook..."
 
 EXTENSION_DIR="$(git rev-parse --git-dir)/prbuddy"
 PORT_FILE="$EXTENSION_DIR/.prbuddy_port"
@@ -57,6 +57,6 @@ fi
 		return fmt.Errorf("failed to write post-commit hook: %w", err)
 	}
 
-	fmt.Printf("[prbuddy-go] post-commit hook installed at %s\n", postCommitPath)
+	fmt.Printf("[PRBuddy-Go] post-commit hook installed at %s\n", postCommitPath)
 	return nil
 }

--- a/internal/hooks/install_hook.go
+++ b/internal/hooks/install_hook.go
@@ -58,7 +58,7 @@ if [ -f .git/prbuddy_run ]; then
 
   if [ "$RUN_PR_BUDDY" = "1" ]; then
     echo "` + colorutils.Green("[PRBuddy-Go] Generating PR as requested...") + `"
-    prbuddy-go post-commit
+    prbuddy-go post-commit --non-interactive
   else
     echo "` + colorutils.Yellow("[PRBuddy-Go] Skipping PR generation as requested.") + `"
   fi

--- a/internal/hooks/remove_hook.go
+++ b/internal/hooks/remove_hook.go
@@ -20,7 +20,7 @@ func RemovePostCommitHook() error {
 	postCommitPath := filepath.Join(repoPath, ".git", "hooks", "post-commit")
 
 	if _, err := os.Stat(postCommitPath); os.IsNotExist(err) {
-		fmt.Printf("[prbuddy-go] No post-commit hook found at %s\n", postCommitPath)
+		fmt.Printf("[PRBuddy-Go] No post-commit hook found at %s\n", postCommitPath)
 		return nil
 	}
 
@@ -29,6 +29,6 @@ func RemovePostCommitHook() error {
 		return fmt.Errorf("failed to remove post-commit hook: %w", err)
 	}
 
-	fmt.Printf("[prbuddy-go] post-commit hook removed from %s\n", postCommitPath)
+	fmt.Printf("[PRBuddy-Go] post-commit hook removed from %s\n", postCommitPath)
 	return nil
 }

--- a/internal/utils/colorutils/colorutils.go
+++ b/internal/utils/colorutils/colorutils.go
@@ -1,0 +1,12 @@
+package colorutils
+
+import "github.com/fatih/color"
+
+var (
+	Cyan    = color.New(color.FgCyan).SprintFunc()
+	Green   = color.New(color.FgGreen).SprintFunc()
+	Yellow  = color.New(color.FgYellow).SprintFunc()
+	Red     = color.New(color.FgRed).SprintFunc()
+	Magenta = color.New(color.FgMagenta).SprintFunc()
+	Bold    = color.New(color.Bold).SprintFunc()
+)


### PR DESCRIPTION
### Pull Request Title
Add Color Package and Improve Interactive PR Generation

### Pull Request Description

#### Overview

This pull request aims to enhance the PRBuddy-Go experience by adding a color package for improved terminal visibility, as well as refining how it interacts with users when generating pull requests.


## Changes

**Files Modified:**

- **cmd/common.go**: Added comments to ignore linter warnings on unused color variables.
- **cmd/post_commit.go**: Updated the `postCommitCmd.Flags` function to include a new flag for `nonInteractive`.
- **internal/hooks/install_hook.sh**: Modified the invocation of the `prbuddy-go post-commit` command by adding the `--non-interactive` flag.


1. **Updated Command Package:** The `cmd/common.go` file has been updated to include additional colors from the new color package, enhancing command output readability.
2. **Interactive PR Generation Improved:**
   - In `internal/hooks/install_hook.go`, we've added a pre-commit hook that checks whether the user wants to generate a pull request upon commit detection.
   - This is done by prompting the user in the terminal and writing their decision to `.git/prbuddy_run`. The post-commit hook has been updated accordingly to check this file before generating the PR.
3. **New Color Utilities:**
   - A new package `internal/utils/colorutils` has been introduced, providing utility functions for various colors. This package is used in both the hooks and common command files.
