### PR TITLE
Added .docs to gitignore and modified hook logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 *.log
 tmp/
 .cspell.json
+/docs

--- a/internal/hooks/install_hook.go
+++ b/internal/hooks/install_hook.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/soyuz43/prbuddy-go/internal/utils"
 	"github.com/soyuz43/prbuddy-go/internal/utils/colorutils"
@@ -25,10 +26,8 @@ func InstallPostCommitHook() error {
 		}
 	}
 
-	// Install post-commit hook
-	postCommitPath := filepath.Join(hooksDir, "post-commit")
-	postCommitHookContent := `#!/bin/bash
-echo "` + colorutils.Cyan("[PRBuddy-Go] Commit detected. Generating pull request...") + `"
+	// Define the hook content
+	prBuddyHookContent := `echo "` + colorutils.Cyan("[PRBuddy-Go] Commit detected. Generating pull request...") + `"
 
 # Run the PR generation command
 prbuddy-go post-commit --non-interactive
@@ -37,14 +36,43 @@ if [ $? -eq 0 ]; then
   echo "` + colorutils.Green("[PRBuddy-Go] Pull request generated successfully.") + `"
 else
   echo "` + colorutils.Red("[PRBuddy-Go] Failed to generate pull request.") + `"
-fi
-`
+fi`
 
-	err = os.WriteFile(postCommitPath, []byte(postCommitHookContent), 0755)
-	if err != nil {
-		return fmt.Errorf("failed to write post-commit hook: %w", err)
+	postCommitPath := filepath.Join(hooksDir, "post-commit")
+
+	// Check if the post-commit hook already exists
+	if _, err := os.Stat(postCommitPath); err == nil {
+		// Read the existing hook content
+		existingContent, err := os.ReadFile(postCommitPath)
+		if err != nil {
+			return fmt.Errorf("failed to read existing post-commit hook: %w", err)
+		}
+
+		// Check if the PRBuddy hook content is already present
+		if strings.Contains(string(existingContent), "prbuddy-go post-commit") {
+			fmt.Println(colorutils.Green("[PRBuddy-Go] post-commit hook already contains PRBuddy logic. Skipping reinstallation."))
+			return nil
+		}
+
+		// Append PRBuddy hook content to the existing hook
+		updatedContent := string(existingContent) + "\n\n# Added by PRBuddy-Go\n" + prBuddyHookContent
+		err = os.WriteFile(postCommitPath, []byte(updatedContent), 0755)
+		if err != nil {
+			return fmt.Errorf("failed to append PRBuddy logic to existing post-commit hook: %w", err)
+		}
+		fmt.Println(colorutils.Green("[PRBuddy-Go] post-commit hook updated with PRBuddy logic."))
+	} else {
+		// If the hook doesn't exist, create a new one
+		newHookContent := `#!/bin/bash
+# Added by PRBuddy-Go
+` + prBuddyHookContent
+
+		err = os.WriteFile(postCommitPath, []byte(newHookContent), 0755)
+		if err != nil {
+			return fmt.Errorf("failed to write post-commit hook: %w", err)
+		}
+		fmt.Printf(colorutils.Cyan("[PRBuddy-Go] post-commit hook installed at %s\n"), postCommitPath)
 	}
-	fmt.Printf(colorutils.Cyan("[PRBuddy-Go] post-commit hook installed at %s\n"), postCommitPath)
 
 	return nil
 }


### PR DESCRIPTION
### Pull Request Title
Add post-commit hook logic for PR generation and ignore .docs files

#### Overview
This pull request updates the PRBuddy-Go project's post-commit hook to include the PR generation command automatically, and adds `.docs` to the `.gitignore` file to ensure that documentation-specific files are not tracked by Git. These changes help streamline the pull request process within the team and keep the repository clean.

---

### Pull Request Description

## Changes Made
- Updated the post-commit hook logic in `internal/hooks/install_hook.go` to check for an existing hook, append PRBuddy logic if needed or create a new one.
- Added `.docs` to the `.gitignore` file in order to ignore documentation-specific files.

### Benefits of Changes
1. **Efficiency in Pull Request Generation:** With the updated post-commit hook, each commit will automatically trigger a check for an existing PRBuddy-Go hook and either append or install it as needed, reducing manual work.
2. **Clarity and Organization:** Ignoring `.docs` files keeps the repository clean and focused on source code.
