### PR TITLE
Added conditional to check for hook installation

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/soyuz43/prbuddy-go/internal/hooks"
 	"github.com/soyuz43/prbuddy-go/internal/utils"
@@ -13,18 +15,35 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize PRBuddy-Go in the current Git repository.",
-	Long:  `Installs a post-commit hook and creates the .git/pr_buddy_db directory.`,
+	Long: `Installs a post-commit hook (optionally) and creates the .git/pr_buddy_db directory.
+If you choose not to install the post-commit hook now, you can install it later manually.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("[PRBuddy-Go] Initializing PRBuddy-Go...")
 
-		// 1. Install post-commit hook
-		if err := hooks.InstallPostCommitHook(); err != nil {
-			fmt.Printf("[PRBuddy-Go] Error installing post-commit hook: %v\n", err)
-			return
-		}
-		fmt.Println("[PRBuddy-Go] Post-commit hook installation complete.")
+		// 1. Prompt the user about installing the post-commit hook
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("[PRBuddy-Go] Generate pr automatically on commit?  [y/N] ")
 
-		// 2. Create pr_buddy_db directory
+		userInput, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("[PRBuddy-Go] Error reading input: %v\n", err)
+			// Fall back to skipping the hook if there's an I/O error
+			userInput = "n"
+		}
+		userInput = strings.TrimSpace(strings.ToLower(userInput))
+
+		if userInput == "y" || userInput == "yes" {
+			// Attempt to install the post-commit hook
+			if err := hooks.InstallPostCommitHook(); err != nil {
+				fmt.Printf("[PRBuddy-Go] Error installing post-commit hook: %v\n", err)
+			} else {
+				fmt.Println("[PRBuddy-Go] Post-commit hook installation complete.")
+			}
+		} else {
+			fmt.Println("[PRBuddy-Go] Skipping post-commit hook installation.")
+		}
+
+		// 2. Create .git/pr_buddy_db directory
 		repoPath, err := utils.GetRepoPath()
 		if err != nil {
 			fmt.Printf("[PRBuddy-Go] Error retrieving repository path: %v\n", err)


### PR DESCRIPTION
# Pull Request Title

Add conditional for optional hook installation during init

---

## Summary

This pull request introduces a conditional check that allows users to choose whether they want to install the post-commit hook when initializing PRBuddy-Go. The `init` command now prompts the user about installing the hook before attempting it, ensuring more flexibility and control over the setup process.

## Details

The following changes were made to implement this feature:

1. **Add new import statement**: A new package, `bufio`, has been imported to facilitate reading input from the standard input.
2. **Modify initCmd.Run function**:
   - Added prompt for user input regarding the installation of the post-commit hook.
   - Implemented a condition to check if the user wants to install the hook based on their input.
   - If the user chooses to install the hook, the existing `hooks.InstallPostCommitHook()` call is executed. Errors during this process are handled and logged appropriately.
   - If the user does not choose to install the hook or if an I/O error occurs during input reading, a message indicating that the post-commit hook installation step has been skipped will be shown.

## Benefits

This change enhances PRBuddy-Go's user experience by making the setup process more adaptable. Users now have the option to selectively choose which components of the tool they want to install right away or defer for later manual installation, depending on their needs and preferences.

## Testing

The code changes should be tested with the `init` command to ensure that:
- The user is prompted for input regarding the hook installation.
- When the user opts in, the post-commit hook gets installed successfully.
- When the user opts out or there's an I/O error, the program skips the hook installation gracefully.

---