### PR TITLE
feat: auto-select and launch fallback model if none is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ prbuddy-go init        # Installs Git hook + .git/pr_buddy_db
 git add .
 git commit -m "feat: add logging"  # Triggers PR draft generation
 ```
+---
+
+## ⚙️ Model Selection
+
+PRBuddy-Go will use:
+
+1. The model set via the extension (`/extension/model`)
+2. `PRBUDDY_LLM_MODEL` environment variable
+3. The most recently pulled model (auto-detected)
+4. If no models are found, PRBuddy will automatically run `qwen3` locally via Ollama.
 
 ---
 


### PR DESCRIPTION
### Pull Request Title


Add automatic fallback model selection with Ollama startup


### Pull Request Body


## ✨ Summary

This PR introduces intelligent fallback behavior when no LLM model is active or configured.

### 🔍 Behavior

- If `contextpkg.GetActiveModel()` is unset, the system now:
  1. Queries Ollama's `/api/ps` endpoint for locally pulled models
  2. Selects the most recently listed model automatically
  3. If no models are found, runs `ollama run qwen3` in the background
  4. Sets the resolved model as active via `setActiveModel(...)`

### 🎯 Why

Previously, if no model was set manually (via `POST /extension/model`) or via the `PRBUDDY_LLM_MODEL` environment variable, the system would silently fall back to `"deepseek-r1:8b"` — which could fail if not installed.

This change improves:

- Startup resilience
- User experience (no silent failures)
- Dev onboarding: one less thing to configure

### 📦 Extras

- Compatible with current `llm_client.go` logic
- No breaking changes — only affects unset/default state

---

✅ Tested locally with Ollama: works both with and without pre-installed models.

