### PR TITLE
refactor: move active model state to contextpkg for shared access

### DIFF
--- a/internal/llm/llm_client.go
+++ b/internal/llm/llm_client.go
@@ -455,7 +455,7 @@ func GetLLMConfig() (string, string) {
 		// Select most recent by default
 		latest := models[0]
 		if name, ok := latest["name"].(string); ok {
-			setActiveModel(name)
+			contextpkg.SetActiveModel(name)
 			return name, endpoint
 		}
 	}
@@ -466,6 +466,6 @@ func GetLLMConfig() (string, string) {
 		_ = exec.Command("ollama", "run", "qwen3").Start()
 	}()
 
-	setActiveModel("qwen3")
+	contextpkg.SetActiveModel("qwen3")
 	return "qwen3", endpoint
 }

--- a/internal/llm/server.go
+++ b/internal/llm/server.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
@@ -20,10 +19,6 @@ import (
 )
 
 // Global model config in memory
-var (
-	modelMutex     sync.RWMutex
-	activeLLMModel string
-)
 
 const (
 	defaultHost              = "localhost"
@@ -220,25 +215,12 @@ func setModelHandler() http.HandlerFunc {
 		if req.Model == "" {
 			return nil, fmt.Errorf("missing 'model' field")
 		}
-		setActiveModel(req.Model)
+		contextpkg.SetActiveModel(req.Model)
 		return map[string]string{
 			"status":       "model updated",
-			"active_model": getActiveModel(),
+			"active_model": contextpkg.GetActiveModel(),
 		}, nil
 	})
-}
-
-// Model management functions
-func setActiveModel(model string) {
-	modelMutex.Lock()
-	defer modelMutex.Unlock()
-	activeLLMModel = model
-}
-
-func getActiveModel() string {
-	modelMutex.RLock()
-	defer modelMutex.RUnlock()
-	return activeLLMModel
 }
 
 func fetchOllamaModels() ([]map[string]interface{}, error) {


### PR DESCRIPTION
## Title: Refactor: Centralize LLM model state in contextpkg


##  What This Does

This PR moves global model selection logic (`activeLLMModel`, mutex, and associated functions) from `llm/server.go` into `contextpkg`, giving the whole application a consistent way to get/set the current LLM model.

##  Why This Matters

Previously, model state was defined locally in `llm/server.go`, but also referenced indirectly in `llm_client.go` and other areas. This created risk of drift or confusion — especially since `contextpkg.GetActiveModel()` was just a stub.

This refactor:

- Consolidates model state in one place
- Enables other modules to access model info safely
- Simplifies future features like persistent model settings or session-aware LLM routing

## 🔧 Summary of Changes

- ✅ Added `SetActiveModel` and `GetActiveModel` to `contextpkg`
- ✅ Removed local model state from `server.go`
- ✅ Updated usage across handlers and client to reference `contextpkg`

## ✅ Tested

- Verified `/extension/model` still sets and returns model
- LLM requests correctly resolve active model state

---

